### PR TITLE
Cause error to inherit from StandardError rather than Exception.

### DIFF
--- a/lib/waveinfo.rb
+++ b/lib/waveinfo.rb
@@ -180,7 +180,7 @@ class WaveInfo
   end
   
   # Exception raised if there is a problem parsing the Wave file
-  class FileFormatError < Exception
+  class FileFormatError < StandardError
   end
   
 end


### PR DESCRIPTION
This is best practice as if you catch Exception, you would also catch Ctrl-C, Out of Memory, or any other critical errors.

http://rubylearning.com/satishtalim/ruby_exceptions.html
