### PR TITLE
Debug flag

### DIFF
--- a/lib/waveinfo.rb
+++ b/lib/waveinfo.rb
@@ -2,6 +2,12 @@
 
 class WaveInfo
 
+  # Set WaveInfo.debug = false to suppress warning messages.
+  class << self
+    attr_accessor :debug
+  end
+  self.debug = true
+
   # Create a new WaveInfo object to get information and metadata about a 
   # Wave file (.wav). 'file' can either be a filename or an IO object.
   def initialize(file)
@@ -139,7 +145,7 @@ class WaveInfo
           @io.seek(subchunk_size,IO::SEEK_CUR)
         else
           pos = sprintf("0x%x", position)
-          $stderr.puts "Warning: unsupported sub-chunk at #{pos}: #{subchunk_id}"
+          $stderr.puts "Warning: unsupported sub-chunk at #{pos}: #{subchunk_id}" if WaveInfo.debug
           @io.seek(subchunk_size,IO::SEEK_CUR)
       end
       position += subchunk_size + 8

--- a/spec/waveinfo_spec.rb
+++ b/spec/waveinfo_spec.rb
@@ -489,21 +489,21 @@ describe WaveInfo do
 
   describe "outputs stderr when debug is true" do
     it "should default to true" do
-      $stderr.should_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      expect($stderr).to receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
       @filepath = sample_path('empty_96k_stereo_24bit_rf64')
       @wav = WaveInfo.new( @filepath )
     end
 
     it "should output to stderr when true" do
       WaveInfo.debug = true
-      $stderr.should_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      expect($stderr).to receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
       @filepath = sample_path('empty_96k_stereo_24bit_rf64')
       @wav = WaveInfo.new( @filepath )
     end
 
     it "should not output to stderr when false" do
       WaveInfo.debug = false
-      $stderr.should_not_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      expect($stderr).to_not receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
       @filepath = sample_path('empty_96k_stereo_24bit_rf64')
       @wav = WaveInfo.new( @filepath )
     end

--- a/spec/waveinfo_spec.rb
+++ b/spec/waveinfo_spec.rb
@@ -9,7 +9,6 @@ describe WaveInfo do
   describe "parsing a Mono 11kHz PCM file with no 'fact' chunk" do
     before :each do
       @filepath = sample_path('sine_11k_mono_16bit_pcm')
-      # WaveInfo.debug = false
       @wav = WaveInfo.new( @filepath )
     end
 
@@ -485,6 +484,28 @@ describe WaveInfo do
     it "should set the audio format name to Unknown for an unknown audio codec" do
       data = StringIO.new("RIFF\x14\0\0\0WAVEfmt \x0a\0\0\0\xff\x00\x02\0\0\0\0\0\0\0\0\0\0\0\0\0")
       expect(WaveInfo.new( data ).audio_format).to eq('Unknown (0xff)')
+    end
+  end
+
+  describe "outputs stderr when debug is true" do
+    it "should default to true" do
+      $stderr.should_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      @filepath = sample_path('empty_96k_stereo_24bit_rf64')
+      @wav = WaveInfo.new( @filepath )
+    end
+
+    it "should output to stderr when true" do
+      WaveInfo.debug = true
+      $stderr.should_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      @filepath = sample_path('empty_96k_stereo_24bit_rf64')
+      @wav = WaveInfo.new( @filepath )
+    end
+
+    it "should not output to stderr when false" do
+      WaveInfo.debug = false
+      $stderr.should_not_receive(:puts).with("Warning: unsupported sub-chunk at 0xc: ds64")
+      @filepath = sample_path('empty_96k_stereo_24bit_rf64')
+      @wav = WaveInfo.new( @filepath )
     end
   end
 end

--- a/spec/waveinfo_spec.rb
+++ b/spec/waveinfo_spec.rb
@@ -9,6 +9,7 @@ describe WaveInfo do
   describe "parsing a Mono 11kHz PCM file with no 'fact' chunk" do
     before :each do
       @filepath = sample_path('sine_11k_mono_16bit_pcm')
+      # WaveInfo.debug = false
       @wav = WaveInfo.new( @filepath )
     end
 


### PR DESCRIPTION
Fix for https://github.com/njh/ruby-waveinfo/issues/4

I kept the present default of outputting the stderr info, although you might want to change that default. There are tests that prove the change.