### PR TITLE
Duration and samples throw error on WAVE file with no sub-chunks

### DIFF
--- a/lib/waveinfo.rb
+++ b/lib/waveinfo.rb
@@ -107,7 +107,7 @@ class WaveInfo
     elsif @block_align.to_f.nonzero?
       @data_size && @block_align ? @data_size / @block_align : 0.0
     else 
-      0
+      0.0
     end
   end
 
@@ -121,7 +121,7 @@ class WaveInfo
     if sample_rate.to_f.nonzero?
       sample_rate ? samples.to_f / sample_rate.to_f : 0.0
     else
-      0
+      0.0
     end
   end
 

--- a/lib/waveinfo.rb
+++ b/lib/waveinfo.rb
@@ -104,8 +104,10 @@ class WaveInfo
   def samples
     if @samples
       @samples
-    else
-      @data_size / @block_align
+    elsif @block_align.to_f.nonzero?
+      @data_size && @block_align ? @data_size / @block_align : 0.0
+    else 
+      0
     end
   end
 
@@ -116,7 +118,11 @@ class WaveInfo
 
   # Get the duration of the audio (in seconds).
   def duration
-    samples.to_f / sample_rate.to_f
+    if sample_rate.to_f.nonzero?
+      sample_rate ? samples.to_f / sample_rate.to_f : 0.0
+    else
+      0
+    end
   end
 
 

--- a/spec/waveinfo_spec.rb
+++ b/spec/waveinfo_spec.rb
@@ -536,6 +536,17 @@ describe WaveInfo do
       data = StringIO.new("RIFF\x14\0\0\0WAVEfmt \x0a\0\0\0\xff\x00\x02\0\0\0\0\0\0\0\0\0\0\0\0\0")
       expect(WaveInfo.new( data ).audio_format).to eq('Unknown (0xff)')
     end
+    
+    it "duration should be zero if WAVE file is valid but has no sub-chunks" do
+      data = StringIO.new("RIFF\4\0\0\0WAVE")
+      expect(WaveInfo.new( data ).duration).to eq(0)
+    end
+    
+    it "samples should be zero if WAVE file is valid but has no sub-chunks" do
+      data = StringIO.new("RIFF\4\0\0\0WAVE")
+      expect(WaveInfo.new( data ).samples).to eq(0)
+    end
+    
   end
 
   describe "WaveInfo.debug" do


### PR DESCRIPTION
I noticed when using WaveInfo on WAVE valid wave files with no data (or sub-chunks) that calling duration or samples would throw the following error:

```
     NoMethodError:
       undefined method `/' for nil:NilClass
```

I've created two tests to catch this error, and submitted a possible fix for the problem. Instead of throwing an error, my proposed changes will return zero instead. Also, I added a few checks to prevent divide by zero.
